### PR TITLE
use `autoreconf -i` to build Makefile.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ sampling-based and model-based simulations are implemented.
 Building PBSIM
 ================
 
-To build PBSIM run:
-  autoconf -i; ./configure; make
-  
+To build PBSIM run;
+
+```bash
+
+ autoreconf -i
+ ./configure
+ make
+ ```
+ 
 A new executable pbsim will be available in the src/ directory
 
 Run PBSIM with sample data


### PR DESCRIPTION
Compiling fails  using `autoconf -i`, confgure requires Makefile.in;

```
$ autoconf -i

$ ./configure
./configure: line 2135: AM_INIT_AUTOMAKE: command not found
...
configure: creating ./config.status
config.status: error: cannot find input file: `Makefile.in'
```

autoreconf -i fixes this

```bash
$ autoreconf -i

$ ./configure
checking for a BSD-compatible install... /usr/bin/install -c
...
config.status: config.h is unchanged
config.status: executing depfiles commands
```
